### PR TITLE
Change number of blocks per year

### DIFF
--- a/contracts/JumpRateModel.sol
+++ b/contracts/JumpRateModel.sol
@@ -15,7 +15,7 @@ contract JumpRateModel is InterestRateModel {
     /**
      * @notice The approximate number of blocks per year that is assumed by the interest rate model
      */
-    uint public constant blocksPerYear = 2102400;
+    uint public constant blocksPerYear = 1051200;
 
     /**
      * @notice The multiplier of utilization rate that gives the slope of the interest rate

--- a/contracts/WhitePaperInterestRateModel.sol
+++ b/contracts/WhitePaperInterestRateModel.sol
@@ -16,7 +16,7 @@ contract WhitePaperInterestRateModel is InterestRateModel {
     /**
      * @notice The approximate number of blocks per year that is assumed by the interest rate model
      */
-    uint public constant blocksPerYear = 2102400;
+    uint public constant blocksPerYear = 1051200;
 
     /**
      * @notice The multiplier of utilization rate that gives the slope of the interest rate

--- a/scenario/src/Value/CTokenValue.ts
+++ b/scenario/src/Value/CTokenValue.ts
@@ -103,7 +103,7 @@ async function getCash(world: World, cToken: CToken): Promise<NumberV> {
 }
 
 async function getInterestRate(world: World, cToken: CToken): Promise<NumberV> {
-  return new NumberV(await cToken.methods.borrowRatePerBlock().call(), 1.0e18 / 2102400);
+  return new NumberV(await cToken.methods.borrowRatePerBlock().call(), 1.0e18 / 1051200);
 }
 
 async function getImplementation(world: World, cToken: CToken): Promise<AddressV> {

--- a/scenario/src/Value/InterestRateModelValue.ts
+++ b/scenario/src/Value/InterestRateModelValue.ts
@@ -17,7 +17,7 @@ export async function getInterestRateModelAddress(world: World, interestRateMode
 }
 
 export async function getBorrowRate(world: World, interestRateModel: InterestRateModel, cash: NumberV, borrows: NumberV, reserves: NumberV): Promise<NumberV> {
-  return new NumberV(await interestRateModel.methods.getBorrowRate(cash.encode(), borrows.encode(), reserves.encode()).call(), 1.0e18 / 2102400);
+  return new NumberV(await interestRateModel.methods.getBorrowRate(cash.encode(), borrows.encode(), reserves.encode()).call(), 1.0e18 / 1051200);
 }
 
 export function interestRateModelFetchers() {

--- a/tests/Models/DAIInterestRateModelTest.js
+++ b/tests/Models/DAIInterestRateModelTest.js
@@ -7,7 +7,7 @@ const {
   getSupplyRate
 } = require('../Utils/Compound');
 
-const blocksPerYear = 2102400;
+const blocksPerYear = 1051200;
 const secondsPerYear = 60 * 60 * 24 * 365;
 
 function utilizationRate(cash, borrows, reserves) {

--- a/tests/Models/InterestRateModelTest.js
+++ b/tests/Models/InterestRateModelTest.js
@@ -55,7 +55,7 @@ function makeUtilization(util) {
   }
 }
 
-const blocksPerYear = 2102400;
+const blocksPerYear = 1051200;
 
 describe('InterestRateModel', () => {
   let root, accounts;

--- a/tests/Tokens/cTokenTest.js
+++ b/tests/Tokens/cTokenTest.js
@@ -68,7 +68,7 @@ describe('CToken', function () {
     it("has a borrow rate", async () => {
       const cToken = await makeCToken({ supportMarket: true, interestRateModelOpts: { kind: 'jump-rate', baseRate: .05, multiplier: 0.45, kink: 0.95, jump: 5 } });
       const perBlock = await call(cToken, 'borrowRatePerBlock');
-      expect(Math.abs(perBlock * 2102400 - 5e16)).toBeLessThanOrEqual(1e8);
+      expect(Math.abs(perBlock * 1051200 - 5e16)).toBeLessThanOrEqual(1e8);
     });
   });
 
@@ -93,7 +93,7 @@ describe('CToken', function () {
       const expectedSuplyRate = borrowRate * .99;
 
       const perBlock = await call(cToken, 'supplyRatePerBlock');
-      expect(Math.abs(perBlock * 2102400 - expectedSuplyRate * 1e18)).toBeLessThanOrEqual(1e8);
+      expect(Math.abs(perBlock * 1051200 - expectedSuplyRate * 1e18)).toBeLessThanOrEqual(1e8);
     });
   });
 


### PR DESCRIPTION
RSK has a block every 30 seconds while Ethereum has a block every 15 seconds
So we change the 2102400 blocks to 1051200